### PR TITLE
Improving rdfs:labelling on DCAT ref data for SKOS hierarchies

### DIFF
--- a/reference/CodeListMetadataManager.py
+++ b/reference/CodeListMetadataManager.py
@@ -18,6 +18,7 @@ import csv
 
 T = TypeVar("T")
 reference_data_base_uri = "http://gss-data.org.uk/def"
+pmdcat_base_uri = "http://publishmydata.com/pmdcat#"
 
 
 def find(xs: List[T], predicate: Callable[[T], bool]) -> Optional[T]:
@@ -80,21 +81,21 @@ def populate_dataset_node(
 ):
     print(f"Processing '{existing_label}' code list ({csv_url})")
 
-    dataset_label = f"Dataset representing {existing_label} code list"
     override(dataset_node, {
         "@id": dataset_uri,
         "@type": [
             "dcat:Dataset",
-            "http://publishmydata.com/pmdcat#Dataset"
+            f"{pmdcat_base_uri}Dataset"
         ],
-        "http://publishmydata.com/pmdcat#datasetContents": {
+        f"{pmdcat_base_uri}datasetContents": {
             "@id": concept_root_uri
         }
     })
 
     supplement(dataset_node, {
-        "rdfs:label": dataset_label,
-        "dc:title": dataset_label,
+        "rdfs:label": existing_label,
+        "dc:title": existing_label,
+        "rdfs:comment": f"Dataset representing the '{existing_label}' code list."
     })
 
     if allow_human_input:
@@ -141,6 +142,14 @@ def populate_dataset_node(
                 "input_request": "Date modified (YYYY-mm-dd)",
                 "to_value": lambda input_value: {"@type": "dateTime",
                                                  "@value": datetime.strptime(input_value, "%Y-%m-%d").isoformat()}
+            },
+            {
+                "name": f"{pmdcat_base_uri}markdownDescription",
+                "input_request": "Markdown Description of Dataset",
+                "to_value": lambda input_value: {
+                    "@type": "https://www.w3.org/ns/iana/media-types/text/markdown#Resource",
+                    "@value": input_value
+                }
             }
         ]
 
@@ -204,8 +213,8 @@ def populate_required_dcat_metadata(
     # Ensure that the skos:ConceptScheme is also of type pmdcat:DatasetContents
     existing_type: Union[str, List[str]] = prov_derivation_object["@type"]
 
-    pmdcat_dataset_contents = "http://publishmydata.com/pmdcat#DatasetContents"
-    pmdcat_concept_scheme = "http://publishmydata.com/pmdcat#ConceptScheme"
+    pmdcat_dataset_contents = f"{pmdcat_base_uri}DatasetContents"
+    pmdcat_concept_scheme = f"{pmdcat_base_uri}ConceptScheme"
     if isinstance(existing_type, str):
         if existing_type != pmdcat_concept_scheme:
             prov_derivation_object["@type"] = [
@@ -300,7 +309,7 @@ def create_metadata_shell_for_csv(csv_file_path: str) -> str:
             "@id": concept_scheme_uri,
             "@type": [
                 "skos:ConceptScheme",
-                "http://publishmydata.com/pmdcat#DatasetContents"
+                f"{pmdcat_base_uri}DatasetContents"
             ]
         }
     }

--- a/reference/codelists/account-type.csv-metadata.json
+++ b/reference/codelists/account-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Account Type code list",
-            "dc:title": "Dataset representing Account Type code list",
+            "rdfs:label": "Account Type",
+            "dc:title": "Account Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/account-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Account Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/age-of-business.csv-metadata.json
+++ b/reference/codelists/age-of-business.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Age Of Business code list",
-            "dc:title": "Dataset representing Age Of Business code list",
+            "rdfs:label": "Age Of Business",
+            "dc:title": "Age Of Business",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/age-of-business"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Age Of Business' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-by-volume.csv-metadata.json
+++ b/reference/codelists/alcohol-by-volume.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol By Volume code list",
-            "dc:title": "Dataset representing Alcohol By Volume code list",
+            "rdfs:label": "Alcohol By Volume",
+            "dc:title": "Alcohol By Volume",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-by-volume"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol By Volume' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-category.csv-metadata.json
+++ b/reference/codelists/alcohol-category.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol Category code list",
-            "dc:title": "Dataset representing Alcohol Category code list",
+            "rdfs:label": "Alcohol Category",
+            "dc:title": "Alcohol Category",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-category"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol Category' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-content.csv-metadata.json
+++ b/reference/codelists/alcohol-content.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol Content code list",
-            "dc:title": "Dataset representing Alcohol Content code list",
+            "rdfs:label": "Alcohol Content",
+            "dc:title": "Alcohol Content",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-content"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol Content' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-duty.csv-metadata.json
+++ b/reference/codelists/alcohol-duty.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol Duty code list",
-            "dc:title": "Dataset representing Alcohol Duty code list",
+            "rdfs:label": "Alcohol Duty",
+            "dc:title": "Alcohol Duty",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-duty"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol Duty' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-origin.csv-metadata.json
+++ b/reference/codelists/alcohol-origin.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol Origin code list",
-            "dc:title": "Dataset representing Alcohol Origin code list",
+            "rdfs:label": "Alcohol Origin",
+            "dc:title": "Alcohol Origin",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-origin"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol Origin' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/alcohol-type.csv-metadata.json
+++ b/reference/codelists/alcohol-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Alcohol Type code list",
-            "dc:title": "Dataset representing Alcohol Type code list",
+            "rdfs:label": "Alcohol Type",
+            "dc:title": "Alcohol Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/alcohol-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Alcohol Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/bop-services.csv-metadata.json
+++ b/reference/codelists/bop-services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Bop Services code list",
-            "dc:title": "Dataset representing Bop Services code list",
+            "rdfs:label": "Bop Services",
+            "dc:title": "Bop Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/bop-services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Bop Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/cord-geographies-wikidata.csv-metadata.json
+++ b/reference/codelists/cord-geographies-wikidata.csv-metadata.json
@@ -87,11 +87,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Cord Geographies Wikidata code list",
-            "dc:title": "Dataset representing Cord Geographies Wikidata code list",
+            "rdfs:label": "Cord Geographies Wikidata",
+            "dc:title": "Cord Geographies Wikidata",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/cord-geographies-wikidata"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Cord Geographies Wikidata' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/cord-geographies.csv-metadata.json
+++ b/reference/codelists/cord-geographies.csv-metadata.json
@@ -79,11 +79,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Cord Geographies code list",
-            "dc:title": "Dataset representing Cord Geographies code list",
+            "rdfs:label": "Cord Geographies",
+            "dc:title": "Cord Geographies",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/cord-geographies"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Cord Geographies' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/cord-sitc.csv-metadata.json
+++ b/reference/codelists/cord-sitc.csv-metadata.json
@@ -79,11 +79,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Cord Sitc code list",
-            "dc:title": "Dataset representing Cord Sitc code list",
+            "rdfs:label": "Cord Sitc",
+            "dc:title": "Cord Sitc",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/cord-sitc"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Cord Sitc' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/countries-of-ownership.csv-metadata.json
+++ b/reference/codelists/countries-of-ownership.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Countries Of Ownership code list",
-            "dc:title": "Dataset representing Countries Of Ownership code list",
+            "rdfs:label": "Countries Of Ownership",
+            "dc:title": "Countries Of Ownership",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/countries-of-ownership"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Countries Of Ownership' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/country-transaction.csv-metadata.json
+++ b/reference/codelists/country-transaction.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Country Transaction code list",
-            "dc:title": "Dataset representing Country Transaction code list",
+            "rdfs:label": "Country Transaction",
+            "dc:title": "Country Transaction",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/country-transaction"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Country Transaction' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/earnings.csv-metadata.json
+++ b/reference/codelists/earnings.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Earnings code list",
-            "dc:title": "Dataset representing Earnings code list",
+            "rdfs:label": "Earnings",
+            "dc:title": "Earnings",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/earnings"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Earnings' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/employment-size-bands.csv-metadata.json
+++ b/reference/codelists/employment-size-bands.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Employment Size Bands code list",
-            "dc:title": "Dataset representing Employment Size Bands code list",
+            "rdfs:label": "Employment Size Bands",
+            "dc:title": "Employment Size Bands",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/employment-size-bands"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Employment Size Bands' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/eu-rw-ww.csv-metadata.json
+++ b/reference/codelists/eu-rw-ww.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Eu Rw Ww code list",
-            "dc:title": "Dataset representing Eu Rw Ww code list",
+            "rdfs:label": "Eu Rw Ww",
+            "dc:title": "Eu Rw Ww",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/eu-rw-ww"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Eu Rw Ww' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/export-services.csv-metadata.json
+++ b/reference/codelists/export-services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Export Services code list",
-            "dc:title": "Dataset representing Export Services code list",
+            "rdfs:label": "Export Services",
+            "dc:title": "Export Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/export-services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Export Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/exporter-and-importer-activity.csv-metadata.json
+++ b/reference/codelists/exporter-and-importer-activity.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Exporter And Importer Activity code list",
-            "dc:title": "Dataset representing Exporter And Importer Activity code list",
+            "rdfs:label": "Exporter And Importer Activity",
+            "dc:title": "Exporter And Importer Activity",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/exporter-and-importer-activity"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Exporter And Importer Activity' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/fdi-component.csv-metadata.json
+++ b/reference/codelists/fdi-component.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Fdi Component code list",
-            "dc:title": "Dataset representing Fdi Component code list",
+            "rdfs:label": "Fdi Component",
+            "dc:title": "Fdi Component",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/fdi-component"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Fdi Component' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/fdi-industry.csv-metadata.json
+++ b/reference/codelists/fdi-industry.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Fdi Industry code list",
-            "dc:title": "Dataset representing Fdi Industry code list",
+            "rdfs:label": "Fdi Industry",
+            "dc:title": "Fdi Industry",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/fdi-industry"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Fdi Industry' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/flow-directions.csv-metadata.json
+++ b/reference/codelists/flow-directions.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Flow Directions code list",
-            "dc:title": "Dataset representing Flow Directions code list",
+            "rdfs:label": "Flow Directions",
+            "dc:title": "Flow Directions",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/flow-directions"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Flow Directions' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/gdp-estimate-type.csv-metadata.json
+++ b/reference/codelists/gdp-estimate-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Gdp Estimate Type code list",
-            "dc:title": "Dataset representing Gdp Estimate Type code list",
+            "rdfs:label": "Gdp Estimate Type",
+            "dc:title": "Gdp Estimate Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/gdp-estimate-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Gdp Estimate Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/hmrc-geographies-wikidata.csv-metadata.json
+++ b/reference/codelists/hmrc-geographies-wikidata.csv-metadata.json
@@ -84,11 +84,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Hmrc Geographies Wikidata code list",
-            "dc:title": "Dataset representing Hmrc Geographies Wikidata code list",
+            "rdfs:label": "Hmrc Geographies Wikidata",
+            "dc:title": "Hmrc Geographies Wikidata",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/hmrc-geographies-wikidata"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Hmrc Geographies Wikidata' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/hmrc-geographies.csv-metadata.json
+++ b/reference/codelists/hmrc-geographies.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Hmrc Geographies code list",
-            "dc:title": "Dataset representing Hmrc Geographies code list",
+            "rdfs:label": "Hmrc Geographies",
+            "dc:title": "Hmrc Geographies",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/hmrc-geographies"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Hmrc Geographies' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/hmrc-industry-groups.csv-metadata.json
+++ b/reference/codelists/hmrc-industry-groups.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Hmrc Industry Groups code list",
-            "dc:title": "Dataset representing Hmrc Industry Groups code list",
+            "rdfs:label": "Hmrc Industry Groups",
+            "dc:title": "Hmrc Industry Groups",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/hmrc-industry-groups"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Hmrc Industry Groups' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/hmrc-regions.csv-metadata.json
+++ b/reference/codelists/hmrc-regions.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Hmrc Regions code list",
-            "dc:title": "Dataset representing Hmrc Regions code list",
+            "rdfs:label": "Hmrc Regions",
+            "dc:title": "Hmrc Regions",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/hmrc-regions"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Hmrc Regions' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/hmrc-trade-statistic-type.csv-metadata.json
+++ b/reference/codelists/hmrc-trade-statistic-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Hmrc Trade Statistic Type code list",
-            "dc:title": "Dataset representing Hmrc Trade Statistic Type code list",
+            "rdfs:label": "Hmrc Trade Statistic Type",
+            "dc:title": "Hmrc Trade Statistic Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/hmrc-trade-statistic-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Hmrc Trade Statistic Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/income-description.csv-metadata.json
+++ b/reference/codelists/income-description.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Income Description code list",
-            "dc:title": "Dataset representing Income Description code list",
+            "rdfs:label": "Income Description",
+            "dc:title": "Income Description",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/income-description"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Income Description' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/income.csv-metadata.json
+++ b/reference/codelists/income.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Income code list",
-            "dc:title": "Dataset representing Income code list",
+            "rdfs:label": "Income",
+            "dc:title": "Income",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/income"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Income' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/international-trade-basis.csv-metadata.json
+++ b/reference/codelists/international-trade-basis.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing International Trade Basis code list",
-            "dc:title": "Dataset representing International Trade Basis code list",
+            "rdfs:label": "International Trade Basis",
+            "dc:title": "International Trade Basis",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/international-trade-basis"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'International Trade Basis' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/invalid/bpm6-services.csv-metadata.json
+++ b/reference/codelists/invalid/bpm6-services.csv-metadata.json
@@ -79,8 +79,9 @@
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/bpm6-services"
             },
-            "rdfs:label": "Dataset representing Bpm6 Services code list",
-            "dc:title": "Dataset representing Bpm6 Services code list"
+            "rdfs:label": "Bpm6 Services",
+            "dc:title": "Bpm6 Services",
+            "rdfs:comment": "Dataset representing the 'Bpm6 Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/invalid/cn8.csv-metadata.json
+++ b/reference/codelists/invalid/cn8.csv-metadata.json
@@ -79,8 +79,9 @@
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/cn8"
             },
-            "rdfs:label": "Dataset representing Cn8 code list",
-            "dc:title": "Dataset representing Cn8 code list"
+            "rdfs:label": "Cn8",
+            "dc:title": "Cn8",
+            "rdfs:comment": "Dataset representing the 'Cn8' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/investment-direction.csv-metadata.json
+++ b/reference/codelists/investment-direction.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Investment Direction code list",
-            "dc:title": "Dataset representing Investment Direction code list",
+            "rdfs:label": "Investment Direction",
+            "dc:title": "Investment Direction",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/investment-direction"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Investment Direction' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/itis-geographies.csv-metadata.json
+++ b/reference/codelists/itis-geographies.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Itis Geographies code list",
-            "dc:title": "Dataset representing Itis Geographies code list",
+            "rdfs:label": "Itis Geographies",
+            "dc:title": "Itis Geographies",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/itis-geographies"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Itis Geographies' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/itis-industry.csv-metadata.json
+++ b/reference/codelists/itis-industry.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Itis Industry code list",
-            "dc:title": "Dataset representing Itis Industry code list",
+            "rdfs:label": "Itis Industry",
+            "dc:title": "Itis Industry",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/itis-industry"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Itis Industry' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/itis-services.csv-metadata.json
+++ b/reference/codelists/itis-services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Itis Services code list",
-            "dc:title": "Dataset representing Itis Services code list",
+            "rdfs:label": "Itis Services",
+            "dc:title": "Itis Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/itis-services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Itis Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/marker.csv-metadata.json
+++ b/reference/codelists/marker.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Marker code list",
-            "dc:title": "Dataset representing Marker code list",
+            "rdfs:label": "Marker",
+            "dc:title": "Marker",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/marker"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Marker' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/members.csv-metadata.json
+++ b/reference/codelists/members.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Members code list",
-            "dc:title": "Dataset representing Members code list",
+            "rdfs:label": "Members",
+            "dc:title": "Members",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/members"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Members' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/mrets-product.csv-metadata.json
+++ b/reference/codelists/mrets-product.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Mrets Product code list",
-            "dc:title": "Dataset representing Mrets Product code list",
+            "rdfs:label": "Mrets Product",
+            "dc:title": "Mrets Product",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/mrets-product"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Mrets Product' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/mrets-trade-area.csv-metadata.json
+++ b/reference/codelists/mrets-trade-area.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Mrets Trade Area code list",
-            "dc:title": "Dataset representing Mrets Trade Area code list",
+            "rdfs:label": "Mrets Trade Area",
+            "dc:title": "Mrets Trade Area",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/mrets-trade-area"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Mrets Trade Area' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-aggregate.csv-metadata.json
+++ b/reference/codelists/national-accounts-aggregate.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Aggregate code list",
-            "dc:title": "Dataset representing National Accounts Aggregate code list",
+            "rdfs:label": "National Accounts Aggregate",
+            "dc:title": "National Accounts Aggregate",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-aggregate"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Aggregate' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-analysis.csv-metadata.json
+++ b/reference/codelists/national-accounts-analysis.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Analysis code list",
-            "dc:title": "Dataset representing National Accounts Analysis code list",
+            "rdfs:label": "National Accounts Analysis",
+            "dc:title": "National Accounts Analysis",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-analysis"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Analysis' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-capital-formation.csv-metadata.json
+++ b/reference/codelists/national-accounts-capital-formation.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Capital Formation code list",
-            "dc:title": "Dataset representing National Accounts Capital Formation code list",
+            "rdfs:label": "National Accounts Capital Formation",
+            "dc:title": "National Accounts Capital Formation",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-capital-formation"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Capital Formation' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-estimate-type.csv-metadata.json
+++ b/reference/codelists/national-accounts-estimate-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Estimate Type code list",
-            "dc:title": "Dataset representing National Accounts Estimate Type code list",
+            "rdfs:label": "National Accounts Estimate Type",
+            "dc:title": "National Accounts Estimate Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-estimate-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Estimate Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-expenditure-category.csv-metadata.json
+++ b/reference/codelists/national-accounts-expenditure-category.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Expenditure Category code list",
-            "dc:title": "Dataset representing National Accounts Expenditure Category code list",
+            "rdfs:label": "National Accounts Expenditure Category",
+            "dc:title": "National Accounts Expenditure Category",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-expenditure-category"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Expenditure Category' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-expenditure-type.csv-metadata.json
+++ b/reference/codelists/national-accounts-expenditure-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Expenditure Type code list",
-            "dc:title": "Dataset representing National Accounts Expenditure Type code list",
+            "rdfs:label": "National Accounts Expenditure Type",
+            "dc:title": "National Accounts Expenditure Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-expenditure-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Expenditure Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-expenditure.csv-metadata.json
+++ b/reference/codelists/national-accounts-expenditure.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Expenditure code list",
-            "dc:title": "Dataset representing National Accounts Expenditure code list",
+            "rdfs:label": "National Accounts Expenditure",
+            "dc:title": "National Accounts Expenditure",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-expenditure"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Expenditure' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-gdp-measure.csv-metadata.json
+++ b/reference/codelists/national-accounts-gdp-measure.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Gdp Measure code list",
-            "dc:title": "Dataset representing National Accounts Gdp Measure code list",
+            "rdfs:label": "National Accounts Gdp Measure",
+            "dc:title": "National Accounts Gdp Measure",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-gdp-measure"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Gdp Measure' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-growth.csv-metadata.json
+++ b/reference/codelists/national-accounts-growth.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Growth code list",
-            "dc:title": "Dataset representing National Accounts Growth code list",
+            "rdfs:label": "National Accounts Growth",
+            "dc:title": "National Accounts Growth",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-growth"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Growth' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-household-expenditure.csv-metadata.json
+++ b/reference/codelists/national-accounts-household-expenditure.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Household Expenditure code list",
-            "dc:title": "Dataset representing National Accounts Household Expenditure code list",
+            "rdfs:label": "National Accounts Household Expenditure",
+            "dc:title": "National Accounts Household Expenditure",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-household-expenditure"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Household Expenditure' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-income-category.csv-metadata.json
+++ b/reference/codelists/national-accounts-income-category.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Income Category code list",
-            "dc:title": "Dataset representing National Accounts Income Category code list",
+            "rdfs:label": "National Accounts Income Category",
+            "dc:title": "National Accounts Income Category",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-income-category"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Income Category' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-income-indicator.csv-metadata.json
+++ b/reference/codelists/national-accounts-income-indicator.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Income Indicator code list",
-            "dc:title": "Dataset representing National Accounts Income Indicator code list",
+            "rdfs:label": "National Accounts Income Indicator",
+            "dc:title": "National Accounts Income Indicator",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-income-indicator"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Income Indicator' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-industrial-sector.csv-metadata.json
+++ b/reference/codelists/national-accounts-industrial-sector.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Industrial Sector code list",
-            "dc:title": "Dataset representing National Accounts Industrial Sector code list",
+            "rdfs:label": "National Accounts Industrial Sector",
+            "dc:title": "National Accounts Industrial Sector",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-industrial-sector"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Industrial Sector' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-industry.csv-metadata.json
+++ b/reference/codelists/national-accounts-industry.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Industry code list",
-            "dc:title": "Dataset representing National Accounts Industry code list",
+            "rdfs:label": "National Accounts Industry",
+            "dc:title": "National Accounts Industry",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-industry"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Industry' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-inventory.csv-metadata.json
+++ b/reference/codelists/national-accounts-inventory.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Inventory code list",
-            "dc:title": "Dataset representing National Accounts Inventory code list",
+            "rdfs:label": "National Accounts Inventory",
+            "dc:title": "National Accounts Inventory",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-inventory"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Inventory' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/national-accounts-trade-type.csv-metadata.json
+++ b/reference/codelists/national-accounts-trade-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing National Accounts Trade Type code list",
-            "dc:title": "Dataset representing National Accounts Trade Type code list",
+            "rdfs:label": "National Accounts Trade Type",
+            "dc:title": "National Accounts Trade Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/national-accounts-trade-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'National Accounts Trade Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/nuts-geographies.csv-metadata.json
+++ b/reference/codelists/nuts-geographies.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Nuts Geographies code list",
-            "dc:title": "Dataset representing Nuts Geographies code list",
+            "rdfs:label": "Nuts Geographies",
+            "dc:title": "Nuts Geographies",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/nuts-geographies"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Nuts Geographies' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/ons-abs-trades.csv-metadata.json
+++ b/reference/codelists/ons-abs-trades.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Ons Abs Trades code list",
-            "dc:title": "Dataset representing Ons Abs Trades code list",
+            "rdfs:label": "Ons Abs Trades",
+            "dc:title": "Ons Abs Trades",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/ons-abs-trades"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Ons Abs Trades' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/ons-fdi-area.csv-metadata.json
+++ b/reference/codelists/ons-fdi-area.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Ons Fdi Area code list",
-            "dc:title": "Dataset representing Ons Fdi Area code list",
+            "rdfs:label": "Ons Fdi Area",
+            "dc:title": "Ons Fdi Area",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/ons-fdi-area"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Ons Fdi Area' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/ons-functional-categories.csv-metadata.json
+++ b/reference/codelists/ons-functional-categories.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Ons Functional Categories code list",
-            "dc:title": "Dataset representing Ons Functional Categories code list",
+            "rdfs:label": "Ons Functional Categories",
+            "dc:title": "Ons Functional Categories",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/ons-functional-categories"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Ons Functional Categories' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/ons-partner-geography.csv-metadata.json
+++ b/reference/codelists/ons-partner-geography.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Ons Partner Geography code list",
-            "dc:title": "Dataset representing Ons Partner Geography code list",
+            "rdfs:label": "Ons Partner Geography",
+            "dc:title": "Ons Partner Geography",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/ons-partner-geography"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Ons Partner Geography' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/pink-book-services.csv-metadata.json
+++ b/reference/codelists/pink-book-services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Pink Book Services code list",
-            "dc:title": "Dataset representing Pink Book Services code list",
+            "rdfs:label": "Pink Book Services",
+            "dc:title": "Pink Book Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/pink-book-services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Pink Book Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/pinkbook-cdid.csv-metadata.json
+++ b/reference/codelists/pinkbook-cdid.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Pinkbook Cdid code list",
-            "dc:title": "Dataset representing Pinkbook Cdid code list",
+            "rdfs:label": "Pinkbook Cdid",
+            "dc:title": "Pinkbook Cdid",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/pinkbook-cdid"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Pinkbook Cdid' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/price-classifications.csv-metadata.json
+++ b/reference/codelists/price-classifications.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Price Classifications code list",
-            "dc:title": "Dataset representing Price Classifications code list",
+            "rdfs:label": "Price Classifications",
+            "dc:title": "Price Classifications",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/price-classifications"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Price Classifications' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/product-category.csv-metadata.json
+++ b/reference/codelists/product-category.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Product Category code list",
-            "dc:title": "Dataset representing Product Category code list",
+            "rdfs:label": "Product Category",
+            "dc:title": "Product Category",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/product-category"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Product Category' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/product-department.csv-metadata.json
+++ b/reference/codelists/product-department.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Product Department code list",
-            "dc:title": "Dataset representing Product Department code list",
+            "rdfs:label": "Product Department",
+            "dc:title": "Product Department",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/product-department"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Product Department' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/product.csv-metadata.json
+++ b/reference/codelists/product.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Product code list",
-            "dc:title": "Dataset representing Product code list",
+            "rdfs:label": "Product",
+            "dc:title": "Product",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/product"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Product' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/production-and-clearance.csv-metadata.json
+++ b/reference/codelists/production-and-clearance.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Production And Clearance code list",
-            "dc:title": "Dataset representing Production And Clearance code list",
+            "rdfs:label": "Production And Clearance",
+            "dc:title": "Production And Clearance",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/production-and-clearance"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Production And Clearance' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/seasonal-adjustments.csv-metadata.json
+++ b/reference/codelists/seasonal-adjustments.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Seasonal Adjustments code list",
-            "dc:title": "Dataset representing Seasonal Adjustments code list",
+            "rdfs:label": "Seasonal Adjustments",
+            "dc:title": "Seasonal Adjustments",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/seasonal-adjustments"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Seasonal Adjustments' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/sector.csv-metadata.json
+++ b/reference/codelists/sector.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Sector code list",
-            "dc:title": "Dataset representing Sector code list",
+            "rdfs:label": "Sector",
+            "dc:title": "Sector",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/sector"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Sector' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/service-destination-geography.csv-metadata.json
+++ b/reference/codelists/service-destination-geography.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Service Destination Geography code list",
-            "dc:title": "Dataset representing Service Destination Geography code list",
+            "rdfs:label": "Service Destination Geography",
+            "dc:title": "Service Destination Geography",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/service-destination-geography"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Service Destination Geography' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/service-origin-geography.csv-metadata.json
+++ b/reference/codelists/service-origin-geography.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Service Origin Geography code list",
-            "dc:title": "Dataset representing Service Origin Geography code list",
+            "rdfs:label": "Service Origin Geography",
+            "dc:title": "Service Origin Geography",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/service-origin-geography"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Service Origin Geography' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/services.csv-metadata.json
+++ b/reference/codelists/services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Services code list",
-            "dc:title": "Dataset representing Services code list",
+            "rdfs:label": "Services",
+            "dc:title": "Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/sitc4.csv-metadata.json
+++ b/reference/codelists/sitc4.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Sitc4 code list",
-            "dc:title": "Dataset representing Sitc4 code list",
+            "rdfs:label": "Sitc4",
+            "dc:title": "Sitc4",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/sitc4"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Sitc4' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/status.csv-metadata.json
+++ b/reference/codelists/status.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Status code list",
-            "dc:title": "Dataset representing Status code list",
+            "rdfs:label": "Status",
+            "dc:title": "Status",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/status"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Status' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/trade-group.csv-metadata.json
+++ b/reference/codelists/trade-group.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Trade Group code list",
-            "dc:title": "Dataset representing Trade Group code list",
+            "rdfs:label": "Trade Group",
+            "dc:title": "Trade Group",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/trade-group"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Trade Group' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/trade-services.csv-metadata.json
+++ b/reference/codelists/trade-services.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Trade Services code list",
-            "dc:title": "Dataset representing Trade Services code list",
+            "rdfs:label": "Trade Services",
+            "dc:title": "Trade Services",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/trade-services"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Trade Services' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/trades.csv-metadata.json
+++ b/reference/codelists/trades.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Trades code list",
-            "dc:title": "Dataset representing Trades code list",
+            "rdfs:label": "Trades",
+            "dc:title": "Trades",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/trades"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Trades' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/transaction-type.csv-metadata.json
+++ b/reference/codelists/transaction-type.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Transaction Type code list",
-            "dc:title": "Dataset representing Transaction Type code list",
+            "rdfs:label": "Transaction Type",
+            "dc:title": "Transaction Type",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/transaction-type"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Transaction Type' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/codelists/turnover-size-bands.csv-metadata.json
+++ b/reference/codelists/turnover-size-bands.csv-metadata.json
@@ -76,11 +76,12 @@
                 "dcat:Dataset",
                 "http://publishmydata.com/pmdcat#Dataset"
             ],
-            "rdfs:label": "Dataset representing Turnover Size Bands code list",
-            "dc:title": "Dataset representing Turnover Size Bands code list",
+            "rdfs:label": "Turnover Size Bands",
+            "dc:title": "Turnover Size Bands",
             "http://publishmydata.com/pmdcat#datasetContents": {
                 "@id": "http://gss-data.org.uk/def/trade/concept-scheme/turnover-size-bands"
-            }
+            },
+            "rdfs:comment": "Dataset representing the 'Turnover Size Bands' code list."
         },
         {
             "@id": "http://gss-data.org.uk/catalog/vocabularies",

--- a/reference/measures.csv-metadata.json
+++ b/reference/measures.csv-metadata.json
@@ -8,10 +8,7 @@
     "@id": "http://gss-data.org.uk/def/trade/ontology/measures",
     "prov:hadDerivation": {
         "@id": "http://gss-data.org.uk/def/trade/ontology/measures",
-        "@type": [
-            "owl:Ontology",
-            "http://publishmydata.com/pmdcat#GraphDatasetContents"
-        ]
+        "@type": "owl:Ontology"
     },
     "url": "measures.csv",
     "tableSchema": {
@@ -81,42 +78,5 @@
         "aboutUrl": "http://gss-data.org.uk/def/{+namespace}/measure/{+path}"
     },
     "rdfs:label": "GSS Trade Measures",
-    "dc:title": "GSS Trade Measures",
-    "rdfs:seeAlso": [
-        {
-            "@id": "http://gss-data.org.uk/def/trade/ontology/measures/dataset",
-            "@type": [
-                "dcat:Dataset",
-                "http://publishmydata.com/pmdcat#Dataset"
-            ],
-            "http://publishmydata.com/pmdcat#datasetContents": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/measures"
-            },
-            "rdfs:label": "Dataset representing GSS Trade Measures code list",
-            "dc:title": "Dataset representing GSS Trade Measures code list"
-        },
-        {
-            "@id": "http://gss-data.org.uk/catalog/vocabularies",
-            "dcat:record": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/measures/catalog-record"
-            }
-        },
-        {
-            "@id": "http://gss-data.org.uk/def/trade/ontology/measures/catalog-record",
-            "@type": "dcat:CatalogRecord",
-            "foaf:primaryTopic": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/measures/dataset"
-            },
-            "dc:title": "GSS Trade Measures Catalog Record",
-            "rdfs:label": "GSS Trade Measures Catalog Record",
-            "dc:issued": {
-                "@type": "dateTime",
-                "@value": "2020-12-23T16:40:50.887157"
-            },
-            "dc:modified": {
-                "@type": "dateTime",
-                "@value": "2020-12-23T16:40:50.887157"
-            }
-        }
-    ]
+    "dc:title": "GSS Trade Measures"
 }

--- a/reference/properties.csv-metadata.json
+++ b/reference/properties.csv-metadata.json
@@ -8,10 +8,7 @@
     "@id": "http://gss-data.org.uk/def/trade/ontology/properties",
     "prov:hadDerivation": {
         "@id": "http://gss-data.org.uk/def/trade/ontology/properties",
-        "@type": [
-            "owl:Ontology",
-            "http://publishmydata.com/pmdcat#GraphDatasetContents"
-        ]
+        "@type": "owl:Ontology"
     },
     "url": "properties.csv",
     "tableSchema": {
@@ -83,42 +80,5 @@
         "aboutUrl": "http://gss-data.org.uk/def/{+namespace}/property/{+path}"
     },
     "rdfs:label": "GSS Trade Properties",
-    "dc:title": "GSS Trade Properties",
-    "rdfs:seeAlso": [
-        {
-            "@id": "http://gss-data.org.uk/def/trade/ontology/properties/dataset",
-            "@type": [
-                "dcat:Dataset",
-                "http://publishmydata.com/pmdcat#Dataset"
-            ],
-            "http://publishmydata.com/pmdcat#datasetContents": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/properties"
-            },
-            "rdfs:label": "Dataset representing GSS Trade Properties code list",
-            "dc:title": "Dataset representing GSS Trade Properties code list"
-        },
-        {
-            "@id": "http://gss-data.org.uk/catalog/vocabularies",
-            "dcat:record": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/properties/catalog-record"
-            }
-        },
-        {
-            "@id": "http://gss-data.org.uk/def/trade/ontology/properties/catalog-record",
-            "@type": "dcat:CatalogRecord",
-            "foaf:primaryTopic": {
-                "@id": "http://gss-data.org.uk/def/trade/ontology/properties/dataset"
-            },
-            "dc:title": "GSS Trade Properties Catalog Record",
-            "rdfs:label": "GSS Trade Properties Catalog Record",
-            "dc:issued": {
-                "@type": "dateTime",
-                "@value": "2020-12-23T16:40:50.886568"
-            },
-            "dc:modified": {
-                "@type": "dateTime",
-                "@value": "2020-12-23T16:40:50.886568"
-            }
-        }
-    ]
+    "dc:title": "GSS Trade Properties"
 }


### PR DESCRIPTION
Improving the rdfs:label on datasets since PMD displays this prominently displayed in the 'Reference Data' section of PMD.

Also removed the DCAT/PMDCAT functionality from the measures/properties ontologies as they're not `skos:ConceptScheme`s.

https://github.com/GSS-Cogs/pmd-jenkins-library/issues/36