### PR TITLE
ONS-UK-trade-in-goods-by-industry-country-and-commodity 

### DIFF
--- a/datasets/HMRC-alcohol-bulletin/main.py
+++ b/datasets/HMRC-alcohol-bulletin/main.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # ---
 # jupyter:
 #   jupytext:
@@ -13,7 +14,7 @@
 #     name: python3
 # ---
 
-import glob
+# import glob
 from gssutils import *
 from gssutils.metadata import THEME
 import pandas as pd
@@ -50,64 +51,110 @@ with original_tabs.open() as ods_obj:
     book.save_to_memory(file_type = 'xls', stream = excel_obj)
     tableset = messytables.excel.XLSTableSet(fileobj = excel_obj)
     tabs = list(xypath.loader.get_sheets(tableset, "*"))
-
-
-tab = tabs[0]
-print(tab)
 # -
 
-tab = tabs[1]
-
-next_table = pd.DataFrame()
-
-# +
-# %%capture
-
-# %run 'T1.py' 
-next_table = pd.concat([next_table, tidy])
-
-# %run 'T2.py'
-next_table = pd.concat([next_table, tidy])
-
-# %run 'T3.py'
-next_table = pd.concat([next_table, tidy])
-
-# %run 'T4.py'
-next_table = pd.concat([next_table, tidy])
-
-# %run 'R2.py'
+# tab = tabs[1]
+tidy_sheets = []
+for tab in tabs:
+    if 'Document_contents' in tab.name:
+        continue
+    period = tab.excel_ref("A7").expand(DOWN).is_not_blank().is_not_whitespace()
+    alcohol_origin = tab.excel_ref("B6").expand(RIGHT).is_not_blank().is_not_whitespace()
+    observations = alcohol_origin.fill(DOWN).is_not_blank().is_not_whitespace()
+    dimensions = [
+        HDim(period, 'Period', DIRECTLY, LEFT),
+        HDim(alcohol_origin, 'Alcohol Origin', DIRECTLY, ABOVE),
+    ]
+    tidy_sheet = ConversionSegment(tab, dimensions, observations)
+    savepreviewhtml(tidy_sheet, fname=tab.name + "Preview.html")
+    tidy_sheets.append(tidy_sheet.topandas())
+    df = pd.concat(tidy_sheets)
+df
 
 # +
-for column in next_table:
-    if column in ('Alcohol by Volume', 'Alcohol Type', 'Alcohol Origin', 'Production and Clearance'):
-        next_table[column] = next_table[column].str.lstrip()
-        next_table[column] = next_table[column].map(lambda x: pathify(x))
+# with pd.option_context('display.max_rows', None):
+#     df['Alcohol Origin'] == 'Total Wine Duty receipts(£ million)'
 
-next_table['Value'] = next_table['Value'].round(decimals = 2)
 
-# + endofcell="--"
-destinationFolder = Path('out')
-destinationFolder.mkdir(exist_ok=True, parents=True)
+# # with pd.option_context('display.max_rows', None):
+# #     print(df)
 
-TITLE = 'HMRC Alcohol Releases, Production and Clearances - NSA'
-OBS_ID = pathify(TITLE)
-import os
-GROUP_ID = pathify(os.environ.get('JOB_NAME', 'gss_data/trade/' + Path(os.getcwd()).name))
+# import functools
 
-next_table.drop_duplicates().to_csv(destinationFolder / f'{OBS_ID}.csv', index = False)
-# # +
-from gssutils.metadata import THEME
-scraper.set_base_uri('http://gss-data.org.uk')
-scraper.set_dataset_id(f'{GROUP_ID}/{OBS_ID}')
-scraper.dataset.title = TITLE
 
-scraper.dataset.family = 'trade'
-with open(destinationFolder / f'{OBS_ID}.csv-metadata.trig', 'wb') as metadata:
-    metadata.write(scraper.generate_trig())
-# -
+# f1 = df['Alcohol Origin'] == 'Total Wine Duty receipts(£ million)'
+# f2 = df['Alcohol Origin'] == 'Total alcohol duty receipts(£ million)'
 
-schema = CSVWMetadata('https://gss-cogs.github.io/family-trade/reference/')
-schema.create(destinationFolder / f'{OBS_ID}.csv', destinationFolder / f'{OBS_ID}.csv-schema.json')
+# cond_list = [f1, f2]
+# all_cond = functools.reduce(lambda x,y:x & y, cond_list)
+# df[all_cond]
 
-next_table
-# --
+# df.loc[df['Alcohol Origin'].isin(['Total Wine Duty receipts(£ million)']), 'OBS']
+
+# new = df['Alcohol Origin'].isin(['Total Wine Duty receipts(£ million)'])
+# df[new]
+
+# +
+# f2=(df['Alcohol by Volume'] =='£ million')
+# df.loc[f2,'Unit'] = 'GBP Million'
+
+f1 = (df['Alcohol Origin'] == 'Total Wine Duty receipts(£ million)')
+df.loc[f1, 'Unit'] = 'GBP Million'
+# df
+# with pd.option_context('display.max_rows', None):
+#     print(df)
+df.info()
+
+# +
+# next_table = pd.Dataframe()
+
+# +
+# # %%capture
+
+# # %run 'T1.py' 
+# next_table = pd.concat([next_table, tidy])
+
+# # %run 'T2.py'
+# next_table = pd.concat([next_table, tidy])
+
+# # %run 'T3.py'
+# next_table = pd.concat([next_table, tidy])
+
+# # %run 'T4.py'
+# next_table = pd.concat([next_table, tidy])
+
+# # %run 'R2.py'
+
+# +
+# for column in next_table:
+#     if column in ('Alcohol by Volume', 'Alcohol Type', 'Alcohol Origin', 'Production and Clearance'):
+#         next_table[column] = next_table[column].str.lstrip()
+#         next_table[column] = next_table[column].map(lambda x: pathify(x))
+
+# next_table['Value'] = next_table['Value'].round(decimals = 2)
+
+# +
+# destinationFolder = Path('out')
+# destinationFolder.mkdir(exist_ok=True, parents=True)
+
+# TITLE = 'HMRC Alcohol Releases, Production and Clearances - NSA'
+# OBS_ID = pathify(TITLE)
+# import os
+# GROUP_ID = pathify(os.environ.get('JOB_NAME', 'gss_data/trade/' + Path(os.getcwd()).name))
+
+# next_table.drop_duplicates().to_csv(destinationFolder / f'{OBS_ID}.csv', index = False)
+# # # +
+# from gssutils.metadata import THEME
+# scraper.set_base_uri('http://gss-data.org.uk')
+# scraper.set_dataset_id(f'{GROUP_ID}/{OBS_ID}')
+# scraper.dataset.title = TITLE
+
+# scraper.dataset.family = 'trade'
+# with open(destinationFolder / f'{OBS_ID}.csv-metadata.trig', 'wb') as metadata:
+#     metadata.write(scraper.generate_trig())
+# # -
+
+# schema = CSVWMetadata('https://gss-cogs.github.io/family-trade/reference/')
+# schema.create(destinationFolder / f'{OBS_ID}.csv', destinationFolder / f'{OBS_ID}.csv-schema.json')
+
+# next_table

--- a/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/concat_main.py
+++ b/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/concat_main.py
@@ -1,0 +1,118 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: light
+#       format_version: '1.5'
+#       jupytext_version: 1.6.0
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# UK trade in goods by industry, country and commodity, exports and imports
+
+import pandas as pd
+import json
+from gssutils import *
+
+pd.options.mode.chained_assignment = None 
+
+cubes = Cubes("info.json")
+
+# +
+with open ('info.json') as file:
+    info = json.load(file)
+
+landingPage = info['landingPage']
+landingPage
+
+# +
+scraper1 = Scraper(landingPage[0])
+scraper2 = Scraper(landingPage[1])
+
+scraper1.dataset.family = info['families']
+scraper1
+# -
+
+scraper2
+
+distribution1 = scraper1.distribution(latest=True)
+distribution2 = scraper2.distribution(latest=True)
+distribution1
+
+distribution2
+
+tabs1 = distribution1.as_databaker()
+tabs2 = distribution2.as_databaker()
+tabs = tabs1 + tabs2
+
+title1 = distribution1.title
+title2 = distribution2.title
+
+# +
+trace = TransformTrace()
+title = distribution1.title + ' and imports' 
+columns = ['ONS Partner Geography', 'Period','Flow','CORD SITC', 'SIC 2007', 'Measure Type','Value','Unit', 'Marker']
+
+for tab in tabs:
+    if tab.name not in ['tig_ind_ex', 'tig_ind_im']:
+        continue
+    print(tab.name)
+    
+    trace.start(title1, tab, columns, distribution1.downloadURL)
+    trace.start(title2, tab, columns, distribution2.downloadURL)
+    
+    if tab.name == 'tig_ind_ex':
+        flow = 'exports'
+    elif tab.name == 'tig_ind_im':
+        flow = 'imports'
+    print(flow)   
+ 
+    country = tab.filter('country').fill(DOWN).is_not_blank()
+    industry = tab.filter('industry').fill(DOWN).is_not_blank()
+    commodity = tab.filter('commodity').fill(DOWN).is_not_blank()
+    year = tab.excel_ref('E1').expand(RIGHT).is_not_blank()
+
+    observations = year.fill(DOWN).is_not_blank()
+
+    dimensions = [
+                HDimConst('Measure Type', 'GBP Total'),
+                HDimConst('Unit', 'gbp-million'),
+                HDimConst('Flow', flow),
+
+                HDim(year,'Period', DIRECTLY,ABOVE),
+                HDim(country,'ONS Partner Geography', DIRECTLY,LEFT),
+                HDim(commodity,'CORD SITC', DIRECTLY,LEFT),
+                HDim(industry,'SIC 2007', DIRECTLY,LEFT)       
+                ]
+    cs = ConversionSegment(tab, dimensions, observations)
+    tidy_sheet = cs.topandas()
+    trace.store("combined_dataframe", tidy_sheet) 
+# -
+
+pd.set_option('display.float_format', lambda x: '%.1f' % x) 
+
+table = trace.combine_and_trace(title, "combined_dataframe").fillna('')
+
+# +
+table = table[table['OBS'] != 0]
+table.loc[table['DATAMARKER'].astype(str) == '..', 'DATAMARKER'] = 'suppressed'
+table.rename(columns={'OBS': 'Value', 'DATAMARKER' : 'Marker'}, inplace=True)
+
+table['CORD SITC'] = table['CORD SITC'].str[:1]
+table['ONS Partner Geography'] = table['ONS Partner Geography'].str[:2]
+table['SIC 2007'] = table['SIC 2007'].str[:2]
+table
+# -
+
+table['Period'] = 'year/' + table['Period'].str[0:4]
+
+table = table[['ONS Partner Geography', 'Period','Flow','CORD SITC', 'SIC 2007', 'Measure Type', 'Value', 'Unit', 'Marker']]
+
+cubes.add_cube(scraper1, table, title)
+cubes.output_all()
+
+trace.render("spec_v1.html")

--- a/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/exports.py
+++ b/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/exports.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.7.1
+#       jupytext_version: 1.6.0
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -14,95 +14,84 @@
 
 # UK trade in goods by industry, country and commodity, exports
 
-# +
-from gssutils import *
+import pandas as pd
 import json
-from urllib.parse import urljoin
+from gssutils import *
 
-
-if is_interactive():
-    import json
-
-    # We need two landing pages for this recipe, they should be virtually identical (save ending either in imports or exports) 
-    # so im going to hard code but include a sanity check (in case they change on airtables at some point in the future)
-
-    with open("info.json", "r") as f:
-        landing_pages = json.load(f)["landingPage"]
-
-    page = next(p for p in landing_pages if p.endswith('exports'))
-    
-    if page != "https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradeingoodsbyindustrycountryandcommodityexports":
-        raise Exception("Aborting. Hard coded url no longer in sync with airtables landing page.")
-
-else:
-    import sys
-    page = sys.argv[1]
-
-display(page)
-scraper = Scraper(page)
-
-scraper
-# -
+pd.options.mode.chained_assignment = None 
 
 cubes = Cubes("info.json")
-tabs = { tab.name: tab for tab in scraper.distributions[0].as_databaker() }
-list(tabs)
-
-tab = tabs['tig_ind_ex']
-
-country = tab.filter(contains_string('country')).fill(DOWN).is_not_blank().is_not_whitespace()
-
-industry = tab.filter(contains_string('industry')).fill(DOWN).is_not_blank().is_not_whitespace()
-
-commodity = tab.filter(contains_string('commodity')).fill(DOWN).is_not_blank().is_not_whitespace()
-
-year = tab.excel_ref('A1').fill(RIGHT).is_not_blank().is_not_whitespace().is_number()
-
-observations = year.fill(DOWN).is_not_blank().is_not_whitespace()
-
-Dimensions = [
-            HDim(year,'Period',DIRECTLY,ABOVE),
-            HDim(country,'ONS Partner Geography',DIRECTLY,LEFT),
-            HDim(commodity,'CORD SITC',DIRECTLY,LEFT),
-            HDim(industry,'SIC 2007',DIRECTLY,LEFT),
-            HDimConst('Measure Type', 'GBP Total'),
-            HDimConst('Unit', 'gbp-million'),
-            HDimConst('Flow', 'exports')
-            ]
-c1 = ConversionSegment(observations, Dimensions, processTIMEUNIT=True)
-savepreviewhtml(c1, fname=tab.name + "Preview.html")
-table = c1.topandas()
-
-table['DATAMARKER'] = table['DATAMARKER'].map(lambda x:'suppressed' if x == '..' else x )
-
-import numpy as np
-table['OBS'].replace('', np.nan, inplace=True)
-table.rename(columns={'OBS': 'Value', 'DATAMARKER' : 'Marker'}, inplace=True)
-table['Value'] = pd.to_numeric(table['Value'], errors='coerce')
-
-for col in table.columns:
-    if col not in ['Value', 'Period']:
-        table[col] = table[col].astype('category')
-        display(col)
-        display(table[col].cat.categories)
-
-table['CORD SITC'].cat.categories = table['CORD SITC'].cat.categories.map(lambda x: x.split()[0])
-table['ONS Partner Geography'].cat.categories = table['ONS Partner Geography'].cat.categories.map(lambda x: x.split()[0])
-table['SIC 2007'].cat.categories = table['SIC 2007'].cat.categories.map(lambda x: x.split()[0])
-display(table['CORD SITC'].cat.categories)
-display(table['ONS Partner Geography'].cat.categories)
-display(table['SIC 2007'].cat.categories)
-
-table['Period'] = 'year/' + table['Period'].astype(str).str[0:4]
-
-table = table[['ONS Partner Geography', 'Period','Flow','CORD SITC', 'SIC 2007', 'Measure Type','Value','Unit', 'Marker']]
 
 # +
-table.rename(columns={'Flow':'Flow Directions'}, inplace=True)
+with open ('info.json') as file:
+    info = json.load(file)
 
-#Flow has been changed to Flow Direction to differentiate from Migration Flow dimension
+landingPage = info['landingPage'][0]
+landingPage
 # -
 
+scraper = Scraper(landingPage)
+scraper.dataset.family = info['families']
+scraper
+
+distribution = scraper.distribution(latest=True)
+distribution
+
+tabs = distribution.as_databaker()
+tab = tabs[1]  
+print(tab.name)
+
+trace = TransformTrace()
+title = distribution.title
+columns = ['ONS Partner Geography', 'Period','Flow','CORD SITC', 'SIC 2007', 'Measure Type','Value','Unit', 'Marker']
+trace.start(title, tab, columns, distribution.downloadURL)
+
+# +
+if tab.name == 'tig_ind_ex':
+    flow = 'exports'
+elif tab.name == 'tig_ind_im':
+    flow = 'imports'
+print(flow)   
+    
+country = tab.filter('country').fill(DOWN).is_not_blank()
+industry = tab.filter('industry').fill(DOWN).is_not_blank()
+commodity = tab.filter('commodity').fill(DOWN).is_not_blank()
+year = tab.excel_ref('E1').expand(RIGHT).is_not_blank()
+   
+observations = year.fill(DOWN).is_not_blank()
+
+dimensions = [
+            HDimConst('Measure Type', 'GBP Total'),
+            HDimConst('Unit', 'gbp-million'),
+            HDimConst('Flow', flow),
+    
+            HDim(year,'Period', DIRECTLY,ABOVE),
+            HDim(country,'ONS Partner Geography', DIRECTLY,LEFT),
+            HDim(commodity,'CORD SITC', DIRECTLY,LEFT),
+            HDim(industry,'SIC 2007', DIRECTLY,LEFT)       
+            ]
+cs = ConversionSegment(tab, dimensions, observations)
+tidy_sheet = cs.topandas()
+trace.store("combined_dataframe", tidy_sheet) 
+
+table = trace.combine_and_trace(title, "combined_dataframe").fillna('')
+# -
+
+pd.set_option('display.float_format', lambda x: '%.1f' % x) 
+
+# +
+table = table[table['OBS'] != 0]
+table.loc[table['DATAMARKER'].astype(str) == '..', 'DATAMARKER'] = 'suppressed'
+table.rename(columns={'OBS': 'Value', 'DATAMARKER' : 'Marker'}, inplace=True)
+
+table['CORD SITC'] = table['CORD SITC'].str[:1]
+table['ONS Partner Geography'] = table['ONS Partner Geography'].str[:2]
+table['SIC 2007'] = table['SIC 2007'].str[:2]
 table
+# -
 
+table['Period'] = 'year/' + table['Period'].str[0:4]
 
+table = table[['ONS Partner Geography', 'Period','Flow','CORD SITC', 'SIC 2007', 'Measure Type', 'Value', 'Unit', 'Marker']]
+
+trace.render("spec_v1.html")

--- a/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/main.py
+++ b/datasets/ONS-UK-trade-in-goods-by-industry-country-and-commodity/main.py
@@ -5,7 +5,7 @@
 #       extension: .py
 #       format_name: light
 #       format_version: '1.5'
-#       jupytext_version: 1.3.3
+#       jupytext_version: 1.6.0
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -19,41 +19,12 @@
 #
 # https://www.ons.gov.uk/economy/nationalaccounts/balanceofpayments/datasets/uktradeingoodsbyindustrycountryandcommodityexports
 
-# +
-from gssutils import *
-import json
-
-cubes = Cubes("info.json")
-with open("info.json", "r") as f:
-    landing_pages = json.load(f)["landingPage"]
-
-
-# +
-def run_script(page):
-    if page.endswith('imports'):
-        %run "imports" {page}
-    else:
-        %run "exports" {page}
-    return table
-
-observations = pd.concat(
-    run_script(page) for page in landing_pages
-).drop_duplicates()
-
-# Temporary repacment of RS for XS code (EU do something odd with serbia for trade)
-# observations["ONS Partner Geography"] = observations["ONS Partner Geography"].str.replace("RS", "XS")
-# -
-
-#Flow has been changed to Flow Direction to differentiate from Migration Flow dimension
-observations.rename(columns={'Flow':'Flow Directions'}, inplace=True)
-cubes.add_cube(scraper, observations, "UK trade in goods by industry,\
-               country and commodity, exports and imports")
+for script in ['exports.py', 'imports.py']:
+    %run $script
+    print(landingPage)
+    print()
+    
+    cubes.add_cube(scraper, table, title)
+    cubes.output_all()
 
 
-from gssutils.metadata import THEME
-scraper.dataset.family = 'trade'
-scraper.dataset.title = scraper.dataset.title.replace('imports', 'imports and exports')
-scraper.dataset.comment = scraper.dataset.comment.replace('import', 'import and export')
-scraper.dataset.landingPage = landing_pages
-
-cubes.output_all()


### PR DESCRIPTION
exports.py and imports.py scripts reworked to produce accurate csv output data.
TransformTrace annotation added to exports.py and imports.py scripts.
main.py reworked to correctly call up exports.py and imports.py, and produce exports and imports csv output data respectively.

As transform requirements are not 'clear', an optional scraper, concat_main.py, was written to concatenate exports and imports datacubes, and produce a single csv output data. 
This scraper does not require exports.py and imports.py.

https://github.com/GSS-Cogs/family-trade/issues/3
